### PR TITLE
Flesh out readme, add i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
 # audacity_vinyl_rip_automation
 I wrote a simple python/ apple script to automate metadata entry for an export of multiple audio files. 
 
-Requirements:
-Runs only on Mac (Apple Script)
-Python
-Audacity
-Internet Connection
-Dope Records
+## Requirements:
+ - Runs only on Mac (Apple Script)
+ - Python
+ - Audacity (with mod-script-pipe module enabled)
+ - Internet Connection
+ - Dope Records
 
+### Configuration
+ - Enable `mod-script-pipe` module in Audacity.  (Audacity => Preferences => Modules)
+ - Enable accessibility permissions for your command line application in macOS system preferences.  (Apple Logo => System Preferences => Security & Privacy => Privacy tab => Accessibility)
+ - Install `discogs_client` python library.
+    ```
+        pip install discogs_client
+    ```
 
-IMPORTANT: while the script is running do not change your cursor (click anywhere) otherwise the apple script will fill out stuff in the wrong areas. 
-IMPORTANT2: The folder you export will be filled with a folder for the album you're exporting. If you repeat this step delete the folder that was created otherwise the apple script will skip the first track because the warning "folder does not exist" will not pop up. 
+**IMPORTANT:** while the script is running do not change your cursor (click anywhere) otherwise the apple script will fill out stuff in the wrong areas.
 
-Instructions: 
+**IMPORTANT2:** The folder you export will be filled with a folder for the album you're exporting. If you repeat this step delete the folder that was created otherwise the apple script will skip the first track because the warning "folder does not exist" will not pop up.
+
+Instructions:
 
 Record your record in audacity.
 Set Text Marks at the beginning of each track. 
@@ -22,9 +30,12 @@ Example:
 https://www.discogs.com/de/release/28985929-Various-W133004
 ID: 28985929
 
-Launch the python script in your terminal.
-Enter the path where you want your output folders to be generated
-Enter the Discogs ID 
+1. Launch the python script in your terminal
+    ```
+        python3 audacity_automation.py
+    ```
+2. Enter the absolute path (/...) where you want your output folders to be generated.
+3. Enter the Discogs ID.
 
 Wait for the script to apply click removal, a Low Cut EQ at 20HZ and then for it to export all your tracks. 
 
@@ -35,5 +46,3 @@ Note2: Some releases give errors, I haven't figured out why yet. Try with a diff
 
 
 I am not a professional developer so might be very buggy. But feel free to use xx
-
-

--- a/audacity_automation.py
+++ b/audacity_automation.py
@@ -12,6 +12,49 @@ import subprocess
 # Platform specific file name and file path.
 # PATH is the location of files to be imported / exported.
 
+# ========================
+# ====   Begin i18n   ====
+# ========================
+LOCALIZED_STRINGS = {
+    'en': {
+        'export_button': "Export"
+    },
+    'de': {
+        'export_button': "Exportieren"
+    }
+}
+
+def get_audacity_language():
+    config_file = os.path.expanduser('~/Library/Application Support/audacity/audacity.cfg')
+    if not os.path.exists(config_file):
+        raise FileNotFoundError(f"The configuration file {config_file} does not exist.")
+
+    language = None
+    with open(config_file, 'r') as file:
+        lines = file.readlines()
+        in_locale_section = False
+        for line in lines:
+            if line.strip() == '[Locale]':
+                in_locale_section = True
+            elif in_locale_section:
+                if line.startswith('Language='):
+                    language = line.split('=')[1].strip()
+                    break
+    return language
+
+language_code = None
+language_code = language_code or get_audacity_language()
+
+def get_localized_string(key,):
+    return LOCALIZED_STRINGS.get(language_code, {}).get(key, key)
+
+export_button_text = None
+export_button_text = export_button_text or get_localized_string('export_button')
+# ======================
+# ====   End i18n   ====
+# ======================
+
+
 #PATH = './'
 PATH = ""
 while not os.path.isdir(PATH):
@@ -182,7 +225,7 @@ apple_script_lines = [
     f'            keystroke "{outputfolder}"',
     '            delay 0.2 -- Ensure the text is entered properly',
     '            -- Press the "exportieren" button',
-    '            click button "Exportieren"',
+    f'            click button "{export_button_text}"',
     '            delay 0.2',
     '        end tell',
     '        keystroke return',


### PR DESCRIPTION
Hey Pino.  Nice script.  Two changes here:  The first clarifies the README a bit, and the seconds adds multi-language compatibility.  Both have the goal of getting the program up and running for more users without a ton of troubleshooting.  See the actual commit messages for more details:

[Add configuration details and formating to README](https://github.com/Pinolinoo/audacity_vinyl_rip_automation/commit/9d2c6424d8db42b733910ab3e3a5470a8b586714)

This changes makes the README file more explicit about the configuration
needed for Audacity and macOS.  It also adds the explicit command to run
the program and markdown formatting for readability for places where the
markdown is rendered, like the GitHub page.

[Add internationalization support](https://github.com/Pinolinoo/audacity_vinyl_rip_automation/commit/517fd391f3aed01f04ac6a772a9fade6fcad61b0)

This change adds i18n support so the script will work regardless of
whether the Audacity interface is in English or German.  Formerly,
the program failed when the Audacity language was set to English,
because it was trying to click a German "Exportieren" button that
was not present.  As of this change only English and German is supported
but a very basic framework to add other locales is in place.